### PR TITLE
## [ FIX ] SP2H3T4 - Refresh agendamento de entrevistas

### DIFF
--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -60,13 +60,11 @@ let calendarOptions = {
   },
   initialView: 'timeGridWeek',
   eventMinHeight: 60,
-  // initialEvents: INITIAL_EVENTS, // alternatively, use the `events` setting to fetch from a feed
   editable: false,
   selectable: false,
   selectMirror: true,
   dayMaxEvents: true,
   weekends: true,
-  // select: handleDateSelect,
   eventClick: null,
   eventsSet: handleEvents,
   themeSystem: 'bootstrap5',

--- a/src/components/Interviews/InterviewsLogged/Candidate/InterviewListItem.vue
+++ b/src/components/Interviews/InterviewsLogged/Candidate/InterviewListItem.vue
@@ -30,7 +30,7 @@
   </td>
   <td class="td-container-icon">
     <p v-if="getInterviewStatus === 'Aguardando agendamento'" class="text-gray-900 whitespace-no-wrap m-auto">
-      <button @click="() => router.push({ name: 'Schedules', params: { id: getInterviewId }})" class="hover:bg-brand-main text-brand-main font-semi-bold hover:text-white py-2 px-4 hover:border-transparent rounded">
+      <button @click="scheduler" class="hover:bg-brand-main text-brand-main font-semi-bold hover:text-white py-2 px-4 hover:border-transparent rounded">
         Agendar
       </button>
     </p>
@@ -45,12 +45,25 @@ export default defineComponent({
   setup() {
     const router = useRouter()
 
+    function scheduler() {
+      window.localStorage.setItem("schedulerInterviewId", this.interview.id.toString())
+      router.push({ name: 'Schedules' })
+    }
+
     return {
-      router
+      router,
+      scheduler
     }
   },
   data: () => ({}),
-  props: ['interview'],
+  props: {
+    interview: {
+      id: String,
+      companyName: String,
+      appointmentDate: String,
+      status: String
+    }
+  },
   computed: {
     getAppointmentDate() {
       if (this.interview.appointmentDate) return this.interview.appointmentDate.toString()

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -53,7 +53,7 @@ const routes = [
     component: Interviews,
   },
   {
-    path: '/schedules/:id',
+    path: '/schedules/',
     name: 'Schedules',
     component: Schedules,
     props: true,


### PR DESCRIPTION
# [ FIX ] SP2H3T4 - Refresh agendamento de entrevistas
### 1. InterviewListItem.vue
Criada função [scheduler] para remover a responsabilidade de redirecionamento para a pagina de agendamento de entrevista, adicionando ao localStorage o id da entrevista a ser agendada.
Criada estrutura de dados para interview na prop com o intuito de facilitar a indexação e facilitar o intendimento de quais atributos devem estar disponíveis.
### 2. Router/index.vue
remoção do parâmetro id passado via na roda, essa responsabilidade foi abordada nos itens ( [schedules](https://github.com/netomantonio/entretien-fe/pull/24#view/schedules/index.vue) e [InterviewListItem](https://github.com/netomantonio/entretien-fe/pull/24#InterviewListItem.vue) )
### 3. view/schedules/index.vue
Alterada a estrutura html com base no componente Calendar.vue que funciona perfeitamente.
Removido [eventSet], o evento não estava sendo efetivo em sua perspectiva.
Removida [handleEvents], a função aparentemente não tinha nenhum efeito funcionoal ou visual no componente.
Alteração [handleInterviewSchedule] adicionado o get do id da entrevista que será agendada no localStorage para efetivar o agendamento no backend, também foi adicionado a remoção do mesmo após a efetivação for concluída e também foi adiconado o redirecionamento do usuário para a pagina de entrevistas ao final.