### PR TITLE
## [ IMPROVEMENTS ] SP3H14T4-Ajustar regras para comparecimento na videochamada

### DIFF
--- a/src/components/Interviews/InterviewsLogged/Candidate/InterviewListItem.vue
+++ b/src/components/Interviews/InterviewsLogged/Candidate/InterviewListItem.vue
@@ -24,8 +24,8 @@
     </span>
   </td>
   <td class="td-container">
-    <p v-if="getAppointmentDate !== null" class="text-gray-900 whitespace-no-wrap m-auto">
-      {{ getAppointmentDate }}
+    <p v-if="this.interview.appointmentDate !== undefined" class="text-gray-900 whitespace-no-wrap m-auto">
+      {{ this.interview.appointmentDate }}
     </p>
   </td>
   <td class="td-container-icon">
@@ -49,7 +49,6 @@
 import {defineComponent} from "vue"
 import InterviewStatus from "@/components/Interviews/InterviewStatus"
 import {useRouter} from 'vue-router'
-import {v4 as uuid} from 'uuid'
 
 const APPLICATION_VIDEO_CALL_URL = process.env.APPLICATION_VIDEO_CALL_URL
 const APPLICATION_SERVER_OPENVIDU_URL = process.env.APPLICATION_SERVER_OPENVIDU_URL
@@ -76,7 +75,8 @@ export default defineComponent({
       id: String,
       companyName: String,
       appointmentDate: String,
-      status: String
+      status: String,
+      sessionId: String
     }
   },
   computed: {
@@ -97,7 +97,7 @@ export default defineComponent({
 
     videoCall() {
       let interviewId = this.interview.id.toString()
-      let sessionID = uuid()
+      let sessionID = this.interview.sessionId
       let token = window.localStorage.getItem('token')
       return APPLICATION_VIDEO_CALL_URL +
         'token=' + token +

--- a/src/components/Interviews/InterviewsLogged/Recruiter/InterviewListItem.vue
+++ b/src/components/Interviews/InterviewsLogged/Recruiter/InterviewListItem.vue
@@ -9,7 +9,7 @@
     </div>
   </td>
   <td class="td-container">
-    <a :href="getSocialNetworking" target="_blank" class="text-gray-900 whitespace-no-wrap m-auto link-personalizado">
+    <a :href="getSocialNetworking" class="text-gray-900 whitespace-no-wrap m-auto link-personalizado" target="_blank">
       {{ getCandidateName }}
     </a>
   </td>
@@ -25,7 +25,8 @@
   </td>
   <td class="td-container">
     <span class="relative inline-block px-3 py-1 font-semi-bold leading-tight">
-      <span class="absolute inset-0 status-pill opacity-50 rounded-full"></span>
+      <span :style="{backgroundColor: getStatusColor}"
+            class="absolute inset-0 status-pill opacity-50 rounded-full"></span>
       <span class="relative m-auto">{{ getInterviewStatus }}</span>
     </span>
   </td>
@@ -44,11 +45,11 @@
     </div>
   </td>
   <td class="td-container-icon">
-<!--    Actions -->
+    <!-- Actions -->
     <p class="text-gray-900 text-center whitespace-no-wrap m-auto">
       <a v-if="getInterviewStatus === 'Agendada' && checkCallLiberation" :href="videoCall"
          class="hover:bg-brand-main text-xs text-brand-main font-semi-bold hover:text-white py-1 px-2 hover:border-transparent rounded"
-         @click="videoCall">
+         @click="$emit('videoCall')">
         Entrar na reunião
       </a>
     </p>
@@ -59,7 +60,6 @@
 import {defineComponent} from "vue";
 import InterviewStatus from "@/components/Interviews/InterviewStatus";
 import {useRouter} from 'vue-router'
-import {v4 as uuid} from "uuid";
 
 const APPLICATION_VIDEO_CALL_URL = process.env.APPLICATION_VIDEO_CALL_URL
 const APPLICATION_SERVER_OPENVIDU_URL = process.env.APPLICATION_SERVER_OPENVIDU_URL
@@ -77,18 +77,18 @@ export default defineComponent({
   data: () => ({}),
   props: {
     interview: {
-      id: String,
-      companyName: String,
-      appointmentDate: String,
-      interviewStatus: String,
-      score: String
+      type: Object,
+      required: true
+    },
+    loadInterview: {
+      type: Function,
+      required: true
     }
   },
   computed: {
-
     checkCallLiberation() {
       let [datePart, timePart] = this.interview.startingAt.toString().split("T")
-      let [year, month, day, ] = datePart.split("-")
+      let [year, month, day,] = datePart.split("-")
       let [hours, minutes] = timePart.split(":")
 
       let monthIndex = parseInt(month, 10) - 1
@@ -99,10 +99,9 @@ export default defineComponent({
       let dataAtual = new Date()
       return dataAtual >= minTimeAcceptableConnection && dataAtual <= maxTimeAcceptableConnection
     },
-
     videoCall() {
       let interviewId = this.interview.id.toString()
-      let sessionID = uuid()
+      let sessionID = this.interview.sessionId
       let token = window.localStorage.getItem('token')
       return APPLICATION_VIDEO_CALL_URL +
         'token=' + token +
@@ -111,9 +110,7 @@ export default defineComponent({
         '&appServerUrl=' + APPLICATION_SERVER_OPENVIDU_URL +
         '&appFrontendUrl=' + APPLICATION_FRONTEND_URL +
         '&userRole=' + 'ROLE_RECRUITER'
-
     },
-
     getSocialNetworking() {
       return this.interview.candidate.socialNetworking
     },
@@ -173,7 +170,7 @@ export default defineComponent({
           return 'gray'
       }
     },
-    getObservation(){
+    getObservation() {
       return this.interview.recruiterObservation.toString()
     }
   }

--- a/src/components/Interviews/InterviewsLogged/Recruiter/index.vue
+++ b/src/components/Interviews/InterviewsLogged/Recruiter/index.vue
@@ -57,7 +57,7 @@
               </thead>
               <tbody>
               <tr v-for="interview in state.interviews" v-bind:key="interview.id">
-                <InterviewListItem :interview="interview"></InterviewListItem>
+                <InterviewListItem :interview="interview" @videoCall="handleVideoCall"  load-interview=""></InterviewListItem>
               </tr>
               </tbody>
             </table>
@@ -98,7 +98,8 @@ export default {
 
     //
     return {
-      state
+      state,
+      loadInterview
     }
   }
 }

--- a/src/services/interview.js
+++ b/src/services/interview.js
@@ -15,7 +15,7 @@ export default httpClient => ({
     }
   },
   getInterviewsByCandidate: async () => {
-    const response = await httpClient.get('/api/candidate/interviews')
+    const response = await httpClient.get('/api/interview/candidate')
     let errors = null
     if (!response.data) {
       errors = {

--- a/src/views/interviewDetails/InterviewStatusListByRecruiterEdit.ts
+++ b/src/views/interviewDetails/InterviewStatusListByRecruiterEdit.ts
@@ -1,6 +1,4 @@
 enum InterviewStatusListByRecruiterEdit {
-  ABSENT_CANDIDATE = 'Candidato ausente',
-  CONCLUDED = 'Concluída',
-  OTHER = 'Outro'
+  CONCLUDED = 'Concluída'
 }
 export default InterviewStatusListByRecruiterEdit


### PR DESCRIPTION
## [ IMPROVEMENTS ] SP3H14T4-Ajustar regras para comparecimento na videochamada

Ajustadas as etapas necessárias para que os redirecionamentos funcionem de maneira automátizada evitando ao máximo que recrutador e candidato tenham responsabilidades para alterar status além do que lhes competem.

para isso foram feitos alguns ajustes na service de interview tbm para garantir a mudança ocorrida no backend com a mudança do endipoint para outra url

na listagem dos item de entrevista foi adicionado o sessionId que é gerado no backend, antes sendo gerado dinamicamente pelos itens do candidato e recrutador o que tava gerando erros de gerenciamento da session.

também foi removido os outros status da opção de edição do recruitador deixando no momento apenas concluída, pois absent_candidate é feita de forma automática evitando que alguém insira essa situação de forma inadequada.